### PR TITLE
Add 'ifTitleFound' option for 'skip'

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ overrides: [{
 
 ## Options
 
-The plugin takes three options, `toTitle` (required), `ifFound` (optional), and `renameDefaultExportsTo` (optional):
+The plugin takes three options, `toTitle` (required), `ifTitleFound` (optional), and `renameDefaultExportsTo` (optional):
 
 - `toTitle` is a function that, for every story file that is transformed, recieves Babel's `state` object, and must return the story file's title as a string. Most `toTitle` implementations will make decisions based on `state.filename`.
 

--- a/README.md
+++ b/README.md
@@ -129,11 +129,16 @@ overrides: [{
 
 ## Options
 
-The plugin takes two options, `toTitle` (required) and `renameDefaultExportsTo` (optional):
+The plugin takes three options, `toTitle` (required), `ifFound` (optional), and `renameDefaultExportsTo` (optional):
 
 - `toTitle` is a function that, for every story file that is transformed, recieves Babel's `state` object, and must return the story file's title as a string. Most `toTitle` implementations will make decisions based on `state.filename`.
 
-- `renameDefaultExportsTo` is an optional string value that controls scenario 3 as described above. It is `undefined` by defaut.
+- `ifFound` is an optional string value that may either be set to:
+  -  `'skip'` - skips adding a title if it has already been manually specified in the code
+  -  `'overwrite'` - overwrites any title already manually specified in the code
+  -  `undefined` (or any other value) - raise an error if processing a file that already defines a title
+
+- `renameDefaultExportsTo` is an optional string value that controls scenario 3 as described above. It is `undefined` by default.
 
 ## Generating meaningful story names
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,8 @@ The plugin takes three options, `toTitle` (required), `ifFound` (optional), and 
 
 - `toTitle` is a function that, for every story file that is transformed, recieves Babel's `state` object, and must return the story file's title as a string. Most `toTitle` implementations will make decisions based on `state.filename`.
 
-- `ifFound` is an optional string value that may either be set to:
+- `ifTitleFound` is an optional string value that may either be set to:
   -  `'skip'` - skips adding a title if it has already been manually specified in the code
-  -  `'overwrite'` - overwrites any title already manually specified in the code
   -  `undefined` (or any other value) - raise an error if processing a file that already defines a title
 
 - `renameDefaultExportsTo` is an optional string value that controls scenario 3 as described above. It is `undefined` by default.

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -111,3 +111,36 @@ tester({
     plugins: ["@babel/plugin-syntax-jsx"],
   }
 });
+
+tester({
+  plugin,
+  tests: [
+      {
+          title: "Default export object with title and ifTitleFound: skip",
+          code: outdent`
+            import React from 'react';
+            import { Component } from './index';
+            export default {
+              title: "existing"
+            };
+            export const Default = () => <Component />;
+          `,
+          output: outdent`
+            import React from 'react';
+            import { Component } from './index';
+            export default {
+              title: "existing"
+            };
+            export const Default = () => <Component />;
+          `
+      }
+  ],
+  pluginOptions: {
+    title: 'bar',
+    toTitle: (state) => state.opts.title,
+    ifTitleFound: 'skip'
+  },
+  babelOptions: {
+    plugins: ["@babel/plugin-syntax-jsx"],
+  }
+});

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,6 @@ const fixObjectDefaultExport = (path, t, title, ifTitleFound) => {
             switch (ifTitleFound) {
                 case 'skip':
                     return;
-                case 'overwrite':
-                    break;
                 default:
                     throw new Error(
                         `Default export object has a '${TITLE_KEY}' property; the title should, however, be generated. Please remove '${TITLE_KEY}'.`

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 const TITLE_KEY = 'title';
 
-const fixObjectDefaultExport = (path, t, title, ifFound) => {
+const fixObjectDefaultExport = (path, t, title, ifTitleFound) => {
     if (path.node.declaration.properties) {
         const titleProperty = path.node.declaration.properties.find(node =>
             node.key && node.key.name === TITLE_KEY
         );
         if (titleProperty) {
-            switch (ifFound) {
+            switch (ifTitleFound) {
                 case 'skip':
                     return;
                 case 'overwrite':
@@ -95,7 +95,7 @@ const plugin = babel => {
 
                     if (state.defaultExportPath) {
                         if (state.defaultExportPath.node.declaration.type === 'ObjectExpression') {
-                            fixObjectDefaultExport(state.defaultExportPath, t, title, state.opts.ifFound);
+                            fixObjectDefaultExport(state.defaultExportPath, t, title, state.opts.ifTitleFound);
                         } else {
                             if (renameDefaultExportsTo) {
                                 if (!state.namedDefaultExportPath) {


### PR DESCRIPTION
Love this plugin, thank you for making it generally available! 👍 

In some cases, we need to either manually specify the title or force overwrite titles without error. This PR adds an optional 'ifTitleFound' param for the plugin, which can specify to either skip if a title is already found. If this param is left undefined or set to any other value, the plugin will continue with existing 'throw' behaviour.